### PR TITLE
Enable concurrent queries to the DataStructure

### DIFF
--- a/include/rt_datastructre.h
+++ b/include/rt_datastructre.h
@@ -22,8 +22,7 @@
 #include <stdbool.h>
 
 ///
-/// C respresentation of a pst instance It also contains and owns the data that was returned at the
-/// last request.
+/// C representation of a pst instance.
 ///
 /// After initializing the pst by the C interface, a pointer DataStructure object will be returned
 /// caller. The pointer should not be modified from outside!
@@ -74,6 +73,12 @@ bool is_good(Datastructure *ds);
 ///
 /// Get the labels contained in the specified bounding box with a t value >= min_t.
 ///
+/// The ownership of the result returned by this function is passed to the caller.
+/// To safely deallocate the result pass it to the function `free_result`.
 C_Result get_data(Datastructure *ds, double min_t, double min_x, double max_x, double min_y, double max_y);
 
 
+///
+/// Deallocate a result returned by `get_data`.
+///
+void free_result(C_Result result);


### PR DESCRIPTION
- DataStructure does no longer own last result
- get_data passes ownership to caller
- free_result has to be called to deallocate the results returned by get_data