### PR TITLE
 Convert bounding box asserts to a function which returns a Result 

### DIFF
--- a/include/rt_datastructre.h
+++ b/include/rt_datastructre.h
@@ -54,6 +54,7 @@ typedef struct C_Label {
 typedef struct C_Result {
 	uint64_t size;
 	C_Label* data;
+        char* error;
 } C_Result;
 
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,6 @@ fn main() {
         }
     }
 
-    let mut tree = pst_3d::Pst3d::new(labels.clone());
 
     // Testing stuff ...
     if testing {

--- a/src/primitives/bbox.rs
+++ b/src/primitives/bbox.rs
@@ -28,6 +28,7 @@ use primitives::label::Label;
 /// The struct defines an axis aligned rectangular area in 2 dimension via min and max in each
 /// dimension X and Y.
 ///
+#[derive(Debug)]
 pub struct BBox {
     m_max_x: f64,
     m_max_y: f64,
@@ -280,5 +281,34 @@ impl BBox {
                 self.m_max_x,
                 self.m_min_y,
                 self.m_max_y)
+    }
+
+    ///
+    /// Check that the bounding box contains valid a coordinate range
+    ///
+    /// Valid coordinates have y-values in the range [-90,90] and
+    /// x-values in the range [-180,180]
+    ///
+    /// # Examples
+    /// ```
+    /// use rt_datastructure::primitives::bbox;
+    ///
+    /// let bb = bbox::BBox::new(1., 2., 3., 4.);
+    /// assert!(bb.check_coordinate_consistency().is_ok());
+    ///
+    /// let bb = bbox::BBox::new(10., -92., 3., 4.);
+    /// assert!(bb.check_coordinate_consistency().is_err());
+    /// ```
+    pub fn check_coordinate_consistency(&self) -> Result<(), &'static str> {
+        // Added .1 to be safe against floating point imprecision
+        if self.m_min_y >= self.m_max_y {
+            return Err("lower y bound is greater than upper y bound");
+        } else if self.m_min_y <= -90.1 || self.m_max_y >= 90.1 {
+            return Err("y values have to be in the range [-90.0, 90.0]");
+        } else if (self.m_min_x <= -180.1 || self.m_min_x >= 180.1) ||
+                  (self.m_max_x <= -180.1 || self.m_max_x >= 180.1) {
+            return Err("x values have to be in the range [-180.0, 180.0]");
+        }
+        Ok(())
     }
 }

--- a/src/pst_3d/mod.rs
+++ b/src/pst_3d/mod.rs
@@ -115,7 +115,7 @@ impl GeoPst3d {
     /// ```
     /// use rt_datastructure::primitives::{label, bbox};
     /// use rt_datastructure::pst_3d;
-    ///
+    ///.
     /// let mut v = Vec::new();
     /// v.push(label::Label::new(1., 2., 10., 1, 1, 1.5, "T1".to_string()));
     /// v.push(label::Label::new(2., 3., 9., 2, 1, 1.5, "T2".to_string()));
@@ -131,7 +131,7 @@ impl GeoPst3d {
     /// let t = pst_3d::GeoPst3d::new(v);
     ///
     /// let bb = bbox::BBox::new(4., 5., 7., 8.);
-    /// let r = t.get(&bb, 4.);
+    /// let r = t.get(&bb, 4.).unwrap();
     ///
     /// for e in &r {
     ///   println!("{}, ", e.to_string());
@@ -160,7 +160,7 @@ impl GeoPst3d {
     /// let t = pst_3d::GeoPst3d::new(v);
     ///
     /// let bb = bbox::BBox::new(170., 0., -170., 90.);
-    /// let r = t.get(&bb, 1.);
+    /// let r = t.get(&bb, 1.).unwrap();
     ///
     /// for e in &r {
     ///   println!("{}, ", e.to_string());
@@ -170,11 +170,8 @@ impl GeoPst3d {
     /// assert!(r.len() == 4);
     /// ```
     ///
-    pub fn get<'a>(&'a self, bbox: &BBox, min_t: f64) -> Vec<&'a Label> {
-        assert!(bbox.get_min_y() <= bbox.get_max_y());
-        assert!(bbox.get_min_y() >= -90. && bbox.get_max_y() <= 90.);
-        assert!(bbox.get_min_x() >= -180. && bbox.get_min_x() <= 180.);
-        assert!(bbox.get_max_x() >= -180. && bbox.get_max_x() <= 180.);
+    pub fn get<'a>(&'a self, bbox: &BBox, min_t: f64) -> Result<Vec<&'a Label>, &'static str> {
+        bbox.check_coordinate_consistency()?;
 
         if bbox.get_max_x() < bbox.get_min_x() {
             let mut res = self.m_pst
@@ -187,10 +184,10 @@ impl GeoPst3d {
                                                 bbox.get_max_y()),
                                      min_t));
 
-            return res;
+            return Ok(res);
         }
 
-        self.m_pst.get(&bbox, min_t)
+        Ok(self.m_pst.get(&bbox, min_t))
     }
 
     ///

--- a/src/pst_3d/mod.rs
+++ b/src/pst_3d/mod.rs
@@ -93,7 +93,7 @@ impl GeoPst3d {
     /// let _ = pst_3d::GeoPst3d::new(v);
     /// ```
     ///
-    pub fn new(mut labels: Vec<Label>) -> GeoPst3d {
+    pub fn new(labels: Vec<Label>) -> GeoPst3d {
         // ensure that each Label has valid coordinates
         let bbox = BBox::new(-180., -90., 180., 90.);
         for l in &labels {
@@ -252,8 +252,6 @@ impl GeoPst3d {
 /// A struct to store the 3d PST and provide a basic interface
 ///
 pub struct Pst3d {
-    m_bbox: BBox,
-
     m_data: Vec<Root>,
     m_root_idx: Option<usize>,
 }
@@ -300,8 +298,6 @@ impl Pst3d {
         let tree_root = Root::init_pst3d(&mut v);
 
         Pst3d {
-            m_bbox: bbox,
-
             m_data: v,
             m_root_idx: tree_root,
         }

--- a/src/pst_3d/root.rs
+++ b/src/pst_3d/root.rs
@@ -91,10 +91,10 @@ impl Root {
         data.sort_by(|first, second| if first.m_t < second.m_t {
                          Ordering::Less
                      } else if first.m_t > second.m_t {
-            Ordering::Greater
-        } else {
-            Ordering::Equal
-        });
+                         Ordering::Greater
+                     } else {
+                         Ordering::Equal
+                     });
         data.reverse();
 
         for (idx, d) in data.iter().enumerate() {
@@ -240,6 +240,7 @@ impl RootRef {
     ///
     /// Compare two Root refs with respect to the t value.
     ///
+    #[allow(dead_code)]
     fn order_by_t(first: &Self, second: &Self) -> Ordering {
         if first.m_t < second.m_t {
             Ordering::Less


### PR DESCRIPTION
The asserts where killing the process which used the library on any
request violating the coordinate value restriction. By returning an
error the code does not need to be duplicated in each user of the lib.